### PR TITLE
Rails 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,4 +52,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.17.3
+   1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,16 +2,17 @@ PATH
   remote: .
   specs:
     fluent_logger_rails (0.2.0)
-      activesupport (~> 5.0, < 6.1)
+      activesupport (>= 5.0, < 6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.4)
+    activesupport (6.0.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2, >= 2.2.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     diff-lcs (1.4.4)
@@ -39,6 +40,7 @@ GEM
     timecop (0.9.1)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
+    zeitwerk (2.4.0)
 
 PLATFORMS
   ruby
@@ -50,4 +52,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/fluent_logger_rails.gemspec
+++ b/fluent_logger_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  spec.add_dependency('activesupport', '~> 5.0', '< 6.1')
+  spec.add_dependency('activesupport', '>= 5.0', '< 6.1')
 
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'timecop'


### PR DESCRIPTION
The `~> 5.0` was still preventing a `6.x` version from satisfying the conditions.