### PR TITLE
Update TaggedHashFormatter to handle nil edge cases gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Bug Fixes:
 
-* None
+* Formatter is now more defensive about incoming nil and array-of-nil values, after changes with Rails 7.x Rack::Logger identified the gap
 
 Enhancements:
 

--- a/lib/fluent_logger_rails/tagged_hash_formatter.rb
+++ b/lib/fluent_logger_rails/tagged_hash_formatter.rb
@@ -43,10 +43,13 @@ module FluentLoggerRails
     end
 
     def tagged(*tags)
-      add_tags(*tags)
-      yield self
+      tags = tags.flatten.compact if tags.is_a?(Array)
+
+      add_tags(*tags) if tags
+
+      yield(self)
     ensure
-      remove_tags(*tags)
+      remove_tags(*tags) if tags
     end
 
     def add_tags(*tags)

--- a/spec/integration/fluent_logger_rails/tagged_hash_formatter_spec.rb
+++ b/spec/integration/fluent_logger_rails/tagged_hash_formatter_spec.rb
@@ -33,6 +33,46 @@ RSpec.describe FluentLoggerRails::TaggedHashFormatter, tz: 'Pacific Time (US & C
     end
   end
 
+  describe '#tagged' do
+    let(:tags) { nil }
+
+    context 'nil tag' do
+      it 'does not attempt to process the tags' do
+        expect(formatter).not_to(receive(:remove_tags).with(anything))
+
+        formatter.tagged(tags) { expect(formatter.current_tags).to(eq({ tags: [] })) }
+      end
+    end
+
+    context 'with a nested array of nil tags' do
+      let(:tags) { [nil] }
+
+      it 'does not attempt to process the tags' do
+        expect(formatter).not_to(receive(:remove_tags).with(anything))
+
+        formatter.tagged([tags]) { expect(formatter.current_tags).to(eq({ tags: [] })) }
+      end
+    end
+
+    context 'with a string tag' do
+      let(:tags) { 'tag' }
+
+      it 'adds the tag' do
+        formatter.tagged(tags) { expect(formatter.current_tags).to(eq({ tags: [tags] })) }
+      end
+    end
+
+    context 'with a hash' do
+      let(:tags) { { port: 80, host: '127.0.0.1' } }
+
+      it 'adds the tags' do
+        formatter.tagged(**tags) do
+          expect(formatter.current_tags).to(eq(tags))
+        end
+      end
+    end
+  end
+
   describe '#add_tags' do
     context 'for a hash' do
       before { formatter.add_tags(host: '127.0.0.1', port: '80')}


### PR DESCRIPTION
With the Rails upgrade from 6.x to 7.x,  came a change in how `Rack::Logger` forwarded on nil tags to the `tagged` method. Previously they had not been splatted upstream which obscured that this Formatter had been passing along arrays of `nil`s. 

Improving the general defensiveness of the code has been enough to test this in both older and newer versions of Rails to success.