### PR TITLE
Disallow Formatter from passing along empty arrays further downstream

### DIFF
--- a/lib/fluent_logger_rails/tagged_hash_formatter.rb
+++ b/lib/fluent_logger_rails/tagged_hash_formatter.rb
@@ -45,11 +45,10 @@ module FluentLoggerRails
     def tagged(*tags)
       tags = tags.flatten.compact if tags.is_a?(Array)
 
-      add_tags(*tags) if tags
-
+      add_tags(*tags) if tags.present?
       yield(self)
     ensure
-      remove_tags(*tags) if tags
+      remove_tags(*tags) if tags.present?
     end
 
     def add_tags(*tags)

--- a/spec/integration/fluent_logger_rails/tagged_hash_formatter_spec.rb
+++ b/spec/integration/fluent_logger_rails/tagged_hash_formatter_spec.rb
@@ -38,9 +38,9 @@ RSpec.describe FluentLoggerRails::TaggedHashFormatter, tz: 'Pacific Time (US & C
 
     context 'nil tag' do
       it 'does not attempt to process the tags' do
-        expect(formatter).not_to(receive(:remove_tags).with(anything))
+        expect_any_instance_of(described_class).not_to receive(:remove_tags)
 
-        formatter.tagged(tags) { expect(formatter.current_tags).to(eq({ tags: [] })) }
+        formatter.tagged(tags) { expect(formatter.current_tags).to eq({}) }
       end
     end
 
@@ -48,17 +48,19 @@ RSpec.describe FluentLoggerRails::TaggedHashFormatter, tz: 'Pacific Time (US & C
       let(:tags) { [nil] }
 
       it 'does not attempt to process the tags' do
-        expect(formatter).not_to(receive(:remove_tags).with(anything))
+        expect_any_instance_of(described_class).not_to receive(:remove_tags)
 
-        formatter.tagged([tags]) { expect(formatter.current_tags).to(eq({ tags: [] })) }
+        formatter.tagged([tags]) { expect(formatter.current_tags).to eq({}) }
       end
     end
 
     context 'with a string tag' do
       let(:tags) { 'tag' }
 
-      it 'adds the tag' do
-        formatter.tagged(tags) { expect(formatter.current_tags).to(eq({ tags: [tags] })) }
+      it 'adds and removes the tag' do
+        expect_any_instance_of(described_class).to receive(:remove_tags).with(tags)
+
+        formatter.tagged(tags) { expect(formatter.current_tags).to eq({ tags: [tags] }) }
       end
     end
 
@@ -66,9 +68,9 @@ RSpec.describe FluentLoggerRails::TaggedHashFormatter, tz: 'Pacific Time (US & C
       let(:tags) { { port: 80, host: '127.0.0.1' } }
 
       it 'adds the tags' do
-        formatter.tagged(**tags) do
-          expect(formatter.current_tags).to(eq(tags))
-        end
+        expect_any_instance_of(described_class).to receive(:remove_tags).with(tags)
+
+        formatter.tagged(**tags) { expect(formatter.current_tags).to eq(tags) }
       end
     end
   end


### PR DESCRIPTION
* Adds an additional check on the Formatter#tagged to refrain from passing empty arrays through
* Diff in the specs is just adding extra hardening around expectations from what methods should be called